### PR TITLE
ci: Test against elasticsearch server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,10 @@ version: 2.0
 
 jobs:
   build:
+    resource_class: small
     docker:
       - image: circleci/golang:1.13.5
+      - image: tetrate/elasticsearch:6.4.3
     environment:
       GOGC: "20"
       GOMAXPROCS: "2"
@@ -12,7 +14,8 @@ jobs:
     steps:
       - checkout
       - run: make
-      # TODO(dio): Add test.
+      - run: ./ci/wait
+      - run: ./ci/test
   release:
     docker:
       - image: circleci/golang:1.13.5

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
-HUB ?= docker.io/tetrate
-TAG ?= dev
+ensure_templates: deps
+	CGO_ENABLED=0 go build -o ensure_templates ./cmd/ensure_templates/main.go
 
 deps:
 	go mod download
-
-build: deps
-	CGO_ENABLED=0 go build -o ensure_templates ./cmd/ensure_templates/main.go
 
 release.dryrun:
 	goreleaser release --skip-publish --snapshot --rm-dist

--- a/ci/test
+++ b/ci/test
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./ensure_templates

--- a/ci/wait
+++ b/ci/wait
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+for i in `seq 1 10`;
+do
+    nc -z localhost 9200 && echo "success" && exit 0
+    echo -n .
+    sleep 5
+done
+echo "failed waiting for elasticsearch" && exit 1


### PR DESCRIPTION
This patch adds a running elasticsearch server on CI to test against the `ensure_templates` binary.

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>