### PR TITLE
adds ability to fetch es user/pass credentials from file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/spf13/pflag v1.0.5
 	github.com/tetratelabs/log v0.0.0-20190710134534-eb04d1e84fb8
+	gopkg.in/yaml.v2 v2.2.1
 )

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -1,0 +1,127 @@
+package credentials
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v2"
+)
+
+// ReadFile is used to extract user/pass credentials for connecting to ES from a file using the provided user/pass
+// extraction paths.
+func ReadFile(fileName, tplUser, tplPass string) (user string, pass string, err error) {
+	var (
+		b   []byte
+		obj interface{}
+	)
+
+	b, err = ioutil.ReadFile(fileName)
+	if err != nil {
+		return "", "", err
+	}
+
+	switch strings.ToLower(filepath.Ext(fileName)) {
+	case ".yml", ".yaml":
+		obj, err = deserializeYAML(b)
+		if err != nil {
+			return
+		}
+	case ".json":
+		obj, err = deserializeJSON(b)
+		if err != nil {
+			return
+		}
+	default:
+		obj, err = deserializeKV(b)
+		if err != nil {
+			return
+		}
+		if tplUser == "" {
+			tplUser = "{{ .username }}"
+		}
+		if tplPass == "" {
+			tplPass = "{{ .password }}"
+		}
+	}
+
+	if tplUser == "" {
+		tplUser = "{{ .data.username }}"
+	}
+
+	if tplPass == "" {
+		tplPass = "{{ .data.password }}"
+	}
+
+	user, err = extractor(obj, tplUser)
+	if err != nil {
+		return "", "", err
+	}
+
+	pass, err = extractor(obj, tplPass)
+	if err != nil {
+		return "", "", err
+	}
+
+	return user, pass, nil
+}
+
+// extractor extracts a value from object based on the provided template.
+func extractor(obj interface{}, tpl string) (string, error) {
+	var b bytes.Buffer
+
+	t, err := template.New("tpl").Parse(tpl)
+	if err != nil {
+		return "", err
+	}
+
+	if err = t.Execute(&b, obj); err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+func deserializeJSON(b []byte) (interface{}, error) {
+	var data interface{}
+
+	if err := json.Unmarshal(b, &data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func deserializeYAML(b []byte) (interface{}, error) {
+	var data interface{}
+
+	if err := yaml.Unmarshal(b, &data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func deserializeKV(b []byte) (interface{}, error) {
+	data := make(map[string]string)
+
+	for _, line := range bytes.Split(b, []byte("\n")) {
+		kv := bytes.SplitN(line, []byte("="), 2)
+		if len(kv) == 2 {
+			data[string(bytes.TrimSpace(kv[0]))] = string(bytes.TrimSpace(kv[1]))
+		} else if len(bytes.TrimSpace(kv[0])) > 0 {
+			log.Printf("unable to parse <key>=<value> pair for: %s", string(kv[0]))
+		}
+	}
+
+	if len(data) == 0 {
+		return nil, errors.New("no key:value pairs found")
+	}
+
+	return data, nil
+}

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -1,0 +1,70 @@
+package credentials_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/tetratelabs/zipkin-es-templater/pkg/credentials"
+)
+
+const (
+	dataJSON = `{
+  "request_id": "82ab8eea-9a07-4682-8cf6-15a21c21843b",
+  "lease_id": "database/creds/my-role/6YWVPFq0BIwkIfsepBSY8dn3",
+  "lease_duration": 3600,
+  "renewable": true,
+  "data": {
+    "password": "A1a-0Ni9XOQddSDVbmiB",
+    "username": "v-root-my-role-cUSnMKfKIbqWbkEhHf3o-1585155604"
+  },
+  "warnings": null
+}`
+
+	dataYAML = `data:
+  password: A1a-juUmf0C0hhXcDtU2
+  username: v-root-my-role-h8680kE1mThPuPjfDUOj-1585155708
+lease_duration: 3600
+lease_id: database/creds/my-role/hZZVv5JqbEKSiJF3nswNmHjz
+renewable: true
+request_id: db1fe564-da3e-ad70-e680-8bf5f0f61e7b
+warnings: null`
+
+	dataKVal = `
+password = A1a-deXmf0C0hhXcDtW8
+username = v-root-my-role-e3880kE1mThPuPjfDUOj-1585155726`
+)
+
+func TestReadFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "es-templater")
+	if err != nil {
+		t.Fatalf("unable to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, item := range []struct {
+		credFileName string
+		credFileData string
+		wantUser     string
+		wantPass     string
+	}{
+		{"creds.json", dataJSON, "v-root-my-role-cUSnMKfKIbqWbkEhHf3o-1585155604", "A1a-0Ni9XOQddSDVbmiB"},
+		{"creds.yaml", dataYAML, "v-root-my-role-h8680kE1mThPuPjfDUOj-1585155708", "A1a-juUmf0C0hhXcDtU2"},
+		{"creds.kval", dataKVal, "v-root-my-role-e3880kE1mThPuPjfDUOj-1585155726", "A1a-deXmf0C0hhXcDtW8"},
+	} {
+		if err = ioutil.WriteFile(dir+"/"+item.credFileName, []byte(item.credFileData), 0644); err != nil {
+			t.Fatalf("unable to create creds file: %v", err)
+		}
+		var gotUser, gotPass string
+		gotUser, gotPass, err = credentials.ReadFile(dir+"/"+item.credFileName, "", "")
+		if err != nil {
+			t.Errorf("unable to parse creds file: %v", err)
+		}
+		if gotUser != item.wantUser {
+			t.Errorf("want user: %v, got user: %v", item.wantUser, gotUser)
+		}
+		if gotPass != item.wantPass {
+			t.Errorf("want pass: %v, got pass: %v", item.wantPass, gotPass)
+		}
+	}
+}


### PR DESCRIPTION
This update allows for easy integration with secrets management tools like Hashicorp Vault.

The templater now accepts `es-credentials-file` as argument to load the username and password from this file. The file can be in `JSON`, `YAML` or `Key=Value` format. JSON files need the `.json` file extension and YAML files the `.yaml` or `.yml` extension.
To support nesting in JSON and YAML it is possible to provide a Go Template variable substitution through the `--es-username` and `--es-password` arguments.

Example credentials file from Vault output: `creds.json`:
```json
{
  "request_id": "27de404d-ce50-18bd-7a37-545dfb2d9125",
  "lease_id": "database/creds/my-role/MoXGHQiBOtQRdKWujMmdFfpw",
  "lease_duration": 3600,
  "renewable": true,
  "data": {
    "password": "A1a-pY8unG3aRa3r9Vp5",
    "username": "v-root-my-role-7B7v7pxPcwd1oGGVMF42-1585155851"
  },
  "warnings": null
}
```

Would need the following command line arguments:
```sh
./ensure_templates --es-credentials-file creds.json --es-username="{{ .data.username}}" --es-password="{{ .data.password}}"
```