### PR TITLE
Switch to tetrate-base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM gcr.io/tetratelabs/tetrate-base:v0.1
 
 COPY ensure_templates /
 


### PR DESCRIPTION
It seems the AWS CA is included in the distro's CA cert bundles. Using an AWS managed Elasticsearch setting [selfSigned](https://docs.tetrate.io/0.8.2/en-us/refs/install/managementplane/v1alpha1/spec/#elasticsearchsettings) to false, all components in management plane are able to talk to the Elasticsearch domain, except for this container. 

This means even if the user may expect an AWS ES domain not to be `selfSigned` it is forced to mark it as self signed and create the `es-certs` with the AWS CA so Zipkin pod can start.

Switching the image to `tetrate-base` which is a scratch image + CA certs works.